### PR TITLE
Fix ArgumentError when Rails.logger is wrapped by SemanticLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 * N/A
 
+## [0.2.1] - 2026-02-23
+
+### Fixed
+- Avoid `ArgumentError: comparison of Symbol with 0 failed` when `Rails.logger` is wrapped by SemanticLogger (or any logger whose `level` is not an integer). Override warnings now only compare level when it is an integer.
+
 ## [0.2.0] - 2026-02-19
 
 ### Changed

--- a/lib/declarative_initialization/internal.rb
+++ b/lib/declarative_initialization/internal.rb
@@ -57,7 +57,10 @@ module DeclarativeInitialization
     def warn_override?
       return true if defined?(Rails) && Rails.respond_to?(:env) && (Rails.env.development? || Rails.env.test?)
 
-      logger.level <= Logger::DEBUG
+      level = logger.level
+      return false unless level.is_a?(Integer)
+
+      level <= Logger::DEBUG
     end
 
     def override_location(klass, key)

--- a/lib/declarative_initialization/version.rb
+++ b/lib/declarative_initialization/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeclarativeInitialization
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/spec/reader_spec.rb
+++ b/spec/reader_spec.rb
@@ -96,6 +96,19 @@ RSpec.describe DeclarativeInitialization do
       allow(DeclarativeInitialization::Internal).to receive(:warn_override?).and_return(true)
     end
 
+    describe "warn_override? with non-standard loggers (e.g. SemanticLogger)" do
+      it "does not compare symbol level with Integer (avoids ArgumentError)" do
+        semantic_logger = instance_double(Logger, level: :info)
+        allow(DeclarativeInitialization::Internal).to receive(:logger).and_return(semantic_logger)
+        allow(DeclarativeInitialization::Internal).to receive(:warn_override?).and_call_original
+        # Ensure we hit the level check (not the Rails dev/test early return)
+        rails_env = Struct.new(:development?, :test?).new(false, false)
+        stub_const("Rails", Class.new { define_singleton_method(:env) { rails_env } })
+
+        expect(DeclarativeInitialization::Internal.warn_override?).to eq(false)
+      end
+    end
+
     def attr_override_warning(key, location: "on this class")
       "[Anonymous Class] Method ##{key} already exists #{location} -- overriding with init-arg reader"
     end


### PR DESCRIPTION
When OS (or any app) wraps `Rails.logger` with SemanticLogger, `logger.level` returns a symbol (e.g. `:info`, `:debug`) instead of the standard Ruby `Logger` integer constants. The override-warning logic in `DeclarativeInitialization::Internal#warn_override?` was doing `logger.level <= Logger::DEBUG`, which raised `ArgumentError: comparison of Symbol with 0 failed` in production.

**Change:** Only compare `logger.level` to `Logger::DEBUG` when `level` is an integer. If the logger uses a non-integer level (e.g. SemanticLogger), skip the level check and do not warn—so behavior in Rails dev/test is unchanged, standard Logger behavior is unchanged, and SemanticLogger (and similar) no longer raise.

Bump to 0.2.1 with changelog entry.
